### PR TITLE
Fix: Remove Header Tags from Login Page to Prevent SEO Impact

### DIFF
--- a/src/components/ui/forms/LoginModal.astro
+++ b/src/components/ui/forms/LoginModal.astro
@@ -30,11 +30,14 @@ const config = {
       >
         <div class="p-4 sm:p-7">
           <div class="text-center">
-            <h2
+            <div
               class="block text-2xl font-bold text-neutral-800 dark:text-neutral-200"
+              role="heading"
+              aria-level="1"
+              aria-label={config.title}
             >
               {config.title}
-            </h2>
+            </div>
             <p class="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
               {config.subTitle}
               <button

--- a/src/components/ui/forms/RecoverModal.astro
+++ b/src/components/ui/forms/RecoverModal.astro
@@ -29,11 +29,14 @@ const config = {
       >
         <div class="p-4 sm:p-7">
           <div class="text-center">
-            <h2
+            <div
               class="block text-2xl font-bold text-neutral-800 dark:text-neutral-200"
+              role="heading"
+              aria-level="1"
+              aria-label={config.title}
             >
               {config.title}
-            </h2>
+            </div>
             <p class="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
               {config.subTitle}
               <!-- Button that, when clicked, opens the login modal -->

--- a/src/components/ui/forms/RegisterModal.astro
+++ b/src/components/ui/forms/RegisterModal.astro
@@ -29,11 +29,14 @@ const config = {
       >
         <div class="p-4 sm:p-7">
           <div class="text-center">
-            <h2
+            <div
               class="block text-2xl font-bold text-neutral-800 dark:text-neutral-200"
+              role="heading"
+              aria-level="1"
+              aria-label={config.title}
             >
               {config.title}
-            </h2>
+            </div>
             <p class="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
               {config.subTitle}
               <!-- Button to toggle login modal -->


### PR DESCRIPTION
This pull request updates the login page to remove <h1>, <h2>, and <h3> tags, which were previously affecting SEO by signaling search engines that the page contained high-priority content. These elements have been replaced with non-semantic alternatives to ensure the login page no longer interferes with the site’s SEO structure