### PR TITLE
fix(docs): update documentation links and navigation for locale support

### DIFF
--- a/src/components/ui/starlight/SiteTitle.astro
+++ b/src/components/ui/starlight/SiteTitle.astro
@@ -3,9 +3,15 @@ import mainLogo from "@images/starlight/screwfast_logo_dark.svg?raw";
 import docsLogo from "@images/starlight/docs_logo.svg?raw";
 
 
-const main = "/";
-const locale = Astro.props.locale ? Astro.props.locale + "/" : "";
-const docs = "/" + locale + "welcome-to-docs/";
+// Try multiple approaches to get current locale
+const locale = Astro.props.lang || Astro.locals.starlightRoute?.locale || Astro.currentLocale || (() => {
+  // Fallback: extract from URL
+  const pathSegments = Astro.url.pathname.split('/').filter(Boolean);
+  return pathSegments[0] || 'en';
+})();
+
+const main = "/" + locale + "/";
+const docs = "/" + locale + "/welcome-to-docs/";
 ---
 
 <span class="site-title flex">

--- a/src/content/docs/de/advanced/technical-specifications.mdx
+++ b/src/content/docs/de/advanced/technical-specifications.mdx
@@ -47,9 +47,9 @@ Explore the possibilities with ScrewFast through real-world scenarios. Our catal
 See how ScrewFast products have been instrumental in:
 
 <CardGrid>
-  <LinkCard title="Major infrastructure projects" href="/guides/getting-started" />
-  <LinkCard title="Innovative architectural accomplishments" href="/guides/getting-started" />
-  <LinkCard title="High-stress industrial applications" href="/guides/getting-started" />
+  <LinkCard title="Major infrastructure projects" href="/de/guides/getting-started" />
+  <LinkCard title="Innovative architectural accomplishments" href="/de/guides/getting-started" />
+  <LinkCard title="High-stress industrial applications" href="/de/guides/getting-started" />
 </CardGrid>
 
 These case studies serve as an inspiration and a learning tool, showcasing what can be achieved with the right expertise and ScrewFast's superior product range.

--- a/src/content/docs/de/construction/safety.mdx
+++ b/src/content/docs/de/construction/safety.mdx
@@ -14,17 +14,17 @@ Safety is at the core of everything we do at ScrewFast. Our comprehensive safety
 
 <LinkCard
   title="Rigorous safety training for all personnel"
-  href="/guides/getting-started"
+  href="/de/guides/getting-started"
 />
 
 <CardGrid>
   <LinkCard
     title="Regular safety audits and compliance checks"
-    href="/guides/getting-started"
+    href="/de/guides/getting-started"
   />
   <LinkCard
     title="Emergency response plans and drills"
-    href="/guides/getting-started"
+    href="/de/guides/getting-started"
   />
 </CardGrid>
 

--- a/src/content/docs/de/tools/equipment-care.mdx
+++ b/src/content/docs/de/tools/equipment-care.mdx
@@ -16,11 +16,11 @@ import {
 <Card title="Maintaining Your ScrewFast Tools" icon="approve-check-circle">
 <LinkCard
   description="Step-by-step guide for the routine care and maintenance of your ScrewFast tools to ensure long-lasting functionality."
-  href="/guides/getting-started"
+  href="/de/guides/getting-started"
 />
 <LinkCard
   description="Cleaning, storage, and inspection practices to keep tools in optimal condition"
-  href="/guides/getting-started"
+  href="/de/guides/getting-started"
 />
 </Card>
 

--- a/src/content/docs/en/advanced/technical-specifications.mdx
+++ b/src/content/docs/en/advanced/technical-specifications.mdx
@@ -47,9 +47,9 @@ Explore the possibilities with ScrewFast through real-world scenarios. Our catal
 See how ScrewFast products have been instrumental in:
 
 <CardGrid>
-  <LinkCard title="Major infrastructure projects" href="/guides/getting-started" />
-  <LinkCard title="Innovative architectural accomplishments" href="/guides/getting-started" />
-  <LinkCard title="High-stress industrial applications" href="/guides/getting-started" />
+  <LinkCard title="Major infrastructure projects" href="/en/guides/getting-started" />
+  <LinkCard title="Innovative architectural accomplishments" href="/en/guides/getting-started" />
+  <LinkCard title="High-stress industrial applications" href="/en/guides/getting-started" />
 </CardGrid>
 
 These case studies serve as an inspiration and a learning tool, showcasing what can be achieved with the right expertise and ScrewFast's superior product range.

--- a/src/content/docs/en/construction/safety.mdx
+++ b/src/content/docs/en/construction/safety.mdx
@@ -14,17 +14,17 @@ Safety is at the core of everything we do at ScrewFast. Our comprehensive safety
 
 <LinkCard
   title="Rigorous safety training for all personnel"
-  href="/guides/getting-started"
+  href="/en/guides/getting-started"
 />
 
 <CardGrid>
   <LinkCard
     title="Regular safety audits and compliance checks"
-    href="/guides/getting-started"
+    href="/en/guides/getting-started"
   />
   <LinkCard
     title="Emergency response plans and drills"
-    href="/guides/getting-started"
+    href="/en/guides/getting-started"
   />
 </CardGrid>
 

--- a/src/content/docs/en/guides/first-project-checklist.mdx
+++ b/src/content/docs/en/guides/first-project-checklist.mdx
@@ -50,16 +50,16 @@ Embarking on a new project can be exciting and challenging in equal measure. Wit
 <LinkCard
   title="Detailed Guides"
   description="Access in-depth documentation and user manuals for ScrewFast tools and services."
-  href="/guides/getting-started"
+  href="/en/guides/getting-started"
 />
 <LinkCard
   title="Support Contacts"
   description="Keep handy the contact details for ScrewFast support, available for assistance throughout your project."
-  href="/guides/getting-started"
+  href="/en/guides/getting-started"
 />
 <LinkCard
   title="Advanced Learning"
   description="Explore further educational resources provided by ScrewFast to refine your skills and knowledge base."
-  href="/guides/getting-started"
+  href="/en/guides/getting-started"
 />
 </CardGrid>

--- a/src/content/docs/en/guides/getting-started.mdx
+++ b/src/content/docs/en/guides/getting-started.mdx
@@ -23,15 +23,15 @@ Welcome to ScrewFast Docs! We're excited to help you get started with our premiu
 <CardGrid>
   <Card title="ScrewDriver Set" icon="seti:config">
     Versatile and ergonomic, suitable for all screw types.
-    <LinkCard title="Learn More " href="/guides/getting-started" />
+    <LinkCard title="Learn More " href="/en/guides/getting-started" />
   </Card>
   <Card title="Hammer Drill" icon="seti:pipeline">
     Powerful performance for drilling and impact driving.
-    <LinkCard title="Learn More " href="/guides/getting-started" />
+    <LinkCard title="Learn More " href="/en/guides/getting-started" />
   </Card>
   <Card title="Power Saws" icon="seti:crystal">
     Precision cutting with adjustable settings for various materials.
-    <LinkCard title="Learn More " href="/guides/getting-started" />
+    <LinkCard title="Learn More " href="/en/guides/getting-started" />
   </Card>
 </CardGrid>
 
@@ -65,17 +65,17 @@ Regular maintenance ensures longevity and safety. Clean your tools after each us
 <LinkCard
   title="In-depth Tutorials"
   description="Deep dive into using our tools with expert-led tutorials."
-  href="en/guides/getting-started"
+  href="/en/guides/getting-started"
 />
 
 <LinkCard
   title="Video Demos"
   description="Visual guides to get the most out of your tools."
-  href="en/guides/getting-started"
+  href="/en/guides/getting-started"
 />
 
 <LinkCard
   title="Warranty Information"
   description="Understand your coverage and how to make a claim if needed."
-  href="en/guides/getting-started"
+  href="/en/guides/getting-started"
 />

--- a/src/content/docs/en/tools/equipment-care.mdx
+++ b/src/content/docs/en/tools/equipment-care.mdx
@@ -16,11 +16,11 @@ import {
 <Card title="Maintaining Your ScrewFast Tools" icon="approve-check-circle">
 <LinkCard
   description="Step-by-step guide for the routine care and maintenance of your ScrewFast tools to ensure long-lasting functionality."
-  href="/guides/getting-started"
+  href="/en/guides/getting-started"
 />
 <LinkCard
   description="Cleaning, storage, and inspection practices to keep tools in optimal condition"
-  href="/guides/getting-started"
+  href="/en/guides/getting-started"
 />
 </Card>
 

--- a/src/content/docs/es/advanced/technical-specifications.mdx
+++ b/src/content/docs/es/advanced/technical-specifications.mdx
@@ -47,9 +47,9 @@ Explore the possibilities with ScrewFast through real-world scenarios. Our catal
 See how ScrewFast products have been instrumental in:
 
 <CardGrid>
-  <LinkCard title="Major infrastructure projects" href="/guides/getting-started" />
-  <LinkCard title="Innovative architectural accomplishments" href="/guides/getting-started" />
-  <LinkCard title="High-stress industrial applications" href="/guides/getting-started" />
+  <LinkCard title="Major infrastructure projects" href="/es/guides/getting-started" />
+  <LinkCard title="Innovative architectural accomplishments" href="/es/guides/getting-started" />
+  <LinkCard title="High-stress industrial applications" href="/es/guides/getting-started" />
 </CardGrid>
 
 These case studies serve as an inspiration and a learning tool, showcasing what can be achieved with the right expertise and ScrewFast's superior product range.

--- a/src/content/docs/es/construction/safety.mdx
+++ b/src/content/docs/es/construction/safety.mdx
@@ -14,17 +14,17 @@ Safety is at the core of everything we do at ScrewFast. Our comprehensive safety
 
 <LinkCard
   title="Rigorous safety training for all personnel"
-  href="/guides/getting-started"
+  href="/es/guides/getting-started"
 />
 
 <CardGrid>
   <LinkCard
     title="Regular safety audits and compliance checks"
-    href="/guides/getting-started"
+    href="/es/guides/getting-started"
   />
   <LinkCard
     title="Emergency response plans and drills"
-    href="/guides/getting-started"
+    href="/es/guides/getting-started"
   />
 </CardGrid>
 

--- a/src/content/docs/es/tools/equipment-care.mdx
+++ b/src/content/docs/es/tools/equipment-care.mdx
@@ -16,11 +16,11 @@ import {
 <Card title="Maintaining Your ScrewFast Tools" icon="approve-check-circle">
 <LinkCard
   description="Step-by-step guide for the routine care and maintenance of your ScrewFast tools to ensure long-lasting functionality."
-  href="/guides/getting-started"
+  href="/es/guides/getting-started"
 />
 <LinkCard
   description="Cleaning, storage, and inspection practices to keep tools in optimal condition"
-  href="/guides/getting-started"
+  href="/es/guides/getting-started"
 />
 </Card>
 

--- a/src/content/docs/fa/advanced/technical-specifications.mdx
+++ b/src/content/docs/fa/advanced/technical-specifications.mdx
@@ -47,9 +47,9 @@ Explore the possibilities with ScrewFast through real-world scenarios. Our catal
 See how ScrewFast products have been instrumental in:
 
 <CardGrid>
-  <LinkCard title="Major infrastructure projects" href="/guides/getting-started" />
-  <LinkCard title="Innovative architectural accomplishments" href="/guides/getting-started" />
-  <LinkCard title="High-stress industrial applications" href="/guides/getting-started" />
+  <LinkCard title="Major infrastructure projects" href="/fa/guides/getting-started" />
+  <LinkCard title="Innovative architectural accomplishments" href="/fa/guides/getting-started" />
+  <LinkCard title="High-stress industrial applications" href="/fa/guides/getting-started" />
 </CardGrid>
 
 These case studies serve as an inspiration and a learning tool, showcasing what can be achieved with the right expertise and ScrewFast's superior product range.

--- a/src/content/docs/fa/construction/safety.mdx
+++ b/src/content/docs/fa/construction/safety.mdx
@@ -14,17 +14,17 @@ Safety is at the core of everything we do at ScrewFast. Our comprehensive safety
 
 <LinkCard
   title="Rigorous safety training for all personnel"
-  href="/guides/getting-started"
+  href="/fa/guides/getting-started"
 />
 
 <CardGrid>
   <LinkCard
     title="Regular safety audits and compliance checks"
-    href="/guides/getting-started"
+    href="/fa/guides/getting-started"
   />
   <LinkCard
     title="Emergency response plans and drills"
-    href="/guides/getting-started"
+    href="/fa/guides/getting-started"
   />
 </CardGrid>
 

--- a/src/content/docs/fa/tools/equipment-care.mdx
+++ b/src/content/docs/fa/tools/equipment-care.mdx
@@ -16,11 +16,11 @@ import {
 <Card title="Maintaining Your ScrewFast Tools" icon="approve-check-circle">
 <LinkCard
   description="Step-by-step guide for the routine care and maintenance of your ScrewFast tools to ensure long-lasting functionality."
-  href="/guides/getting-started"
+  href="/fa/guides/getting-started"
 />
 <LinkCard
   description="Cleaning, storage, and inspection practices to keep tools in optimal condition"
-  href="/guides/getting-started"
+  href="/fa/guides/getting-started"
 />
 </Card>
 

--- a/src/content/docs/fr/advanced/technical-specifications.mdx
+++ b/src/content/docs/fr/advanced/technical-specifications.mdx
@@ -47,9 +47,9 @@ Explore the possibilities with ScrewFast through real-world scenarios. Our catal
 See how ScrewFast products have been instrumental in:
 
 <CardGrid>
-  <LinkCard title="Major infrastructure projects" href="/guides/getting-started" />
-  <LinkCard title="Innovative architectural accomplishments" href="/guides/getting-started" />
-  <LinkCard title="High-stress industrial applications" href="/guides/getting-started" />
+  <LinkCard title="Major infrastructure projects" href="/fr/guides/getting-started" />
+  <LinkCard title="Innovative architectural accomplishments" href="/fr/guides/getting-started" />
+  <LinkCard title="High-stress industrial applications" href="/fr/guides/getting-started" />
 </CardGrid>
 
 These case studies serve as an inspiration and a learning tool, showcasing what can be achieved with the right expertise and ScrewFast's superior product range.

--- a/src/content/docs/fr/construction/safety.mdx
+++ b/src/content/docs/fr/construction/safety.mdx
@@ -14,17 +14,17 @@ Safety is at the core of everything we do at ScrewFast. Our comprehensive safety
 
 <LinkCard
   title="Rigorous safety training for all personnel"
-  href="/guides/getting-started"
+  href="/fr/guides/getting-started"
 />
 
 <CardGrid>
   <LinkCard
     title="Regular safety audits and compliance checks"
-    href="/guides/getting-started"
+    href="/fr/guides/getting-started"
   />
   <LinkCard
     title="Emergency response plans and drills"
-    href="/guides/getting-started"
+    href="/fr/guides/getting-started"
   />
 </CardGrid>
 

--- a/src/content/docs/fr/tools/equipment-care.mdx
+++ b/src/content/docs/fr/tools/equipment-care.mdx
@@ -16,11 +16,11 @@ import {
 <Card title="Maintaining Your ScrewFast Tools" icon="approve-check-circle">
 <LinkCard
   description="Step-by-step guide for the routine care and maintenance of your ScrewFast tools to ensure long-lasting functionality."
-  href="/guides/getting-started"
+  href="/fr/guides/getting-started"
 />
 <LinkCard
   description="Cleaning, storage, and inspection practices to keep tools in optimal condition"
-  href="/guides/getting-started"
+  href="/fr/guides/getting-started"
 />
 </Card>
 

--- a/src/content/docs/ja/advanced/technical-specifications.mdx
+++ b/src/content/docs/ja/advanced/technical-specifications.mdx
@@ -47,9 +47,9 @@ Explore the possibilities with ScrewFast through real-world scenarios. Our catal
 See how ScrewFast products have been instrumental in:
 
 <CardGrid>
-  <LinkCard title="Major infrastructure projects" href="/guides/getting-started" />
-  <LinkCard title="Innovative architectural accomplishments" href="/guides/getting-started" />
-  <LinkCard title="High-stress industrial applications" href="/guides/getting-started" />
+  <LinkCard title="Major infrastructure projects" href="/ja/guides/getting-started" />
+  <LinkCard title="Innovative architectural accomplishments" href="/ja/guides/getting-started" />
+  <LinkCard title="High-stress industrial applications" href="/ja/guides/getting-started" />
 </CardGrid>
 
 These case studies serve as an inspiration and a learning tool, showcasing what can be achieved with the right expertise and ScrewFast's superior product range.

--- a/src/content/docs/ja/construction/safety.mdx
+++ b/src/content/docs/ja/construction/safety.mdx
@@ -14,17 +14,17 @@ Safety is at the core of everything we do at ScrewFast. Our comprehensive safety
 
 <LinkCard
   title="Rigorous safety training for all personnel"
-  href="/guides/getting-started"
+  href="/ja/guides/getting-started"
 />
 
 <CardGrid>
   <LinkCard
     title="Regular safety audits and compliance checks"
-    href="/guides/getting-started"
+    href="/ja/guides/getting-started"
   />
   <LinkCard
     title="Emergency response plans and drills"
-    href="/guides/getting-started"
+    href="/ja/guides/getting-started"
   />
 </CardGrid>
 

--- a/src/content/docs/ja/tools/equipment-care.mdx
+++ b/src/content/docs/ja/tools/equipment-care.mdx
@@ -16,11 +16,11 @@ import {
 <Card title="Maintaining Your ScrewFast Tools" icon="approve-check-circle">
 <LinkCard
   description="Step-by-step guide for the routine care and maintenance of your ScrewFast tools to ensure long-lasting functionality."
-  href="/guides/getting-started"
+  href="/ja/guides/getting-started"
 />
 <LinkCard
   description="Cleaning, storage, and inspection practices to keep tools in optimal condition"
-  href="/guides/getting-started"
+  href="/ja/guides/getting-started"
 />
 </Card>
 

--- a/src/content/docs/zh-cn/advanced/technical-specifications.mdx
+++ b/src/content/docs/zh-cn/advanced/technical-specifications.mdx
@@ -47,9 +47,9 @@ Explore the possibilities with ScrewFast through real-world scenarios. Our catal
 See how ScrewFast products have been instrumental in:
 
 <CardGrid>
-  <LinkCard title="Major infrastructure projects" href="/guides/getting-started" />
-  <LinkCard title="Innovative architectural accomplishments" href="/guides/getting-started" />
-  <LinkCard title="High-stress industrial applications" href="/guides/getting-started" />
+  <LinkCard title="Major infrastructure projects" href="/zh-cn/guides/getting-started" />
+  <LinkCard title="Innovative architectural accomplishments" href="/zh-cn/guides/getting-started" />
+  <LinkCard title="High-stress industrial applications" href="/zh-cn/guides/getting-started" />
 </CardGrid>
 
 These case studies serve as an inspiration and a learning tool, showcasing what can be achieved with the right expertise and ScrewFast's superior product range.

--- a/src/content/docs/zh-cn/construction/safety.mdx
+++ b/src/content/docs/zh-cn/construction/safety.mdx
@@ -14,17 +14,17 @@ Safety is at the core of everything we do at ScrewFast. Our comprehensive safety
 
 <LinkCard
   title="Rigorous safety training for all personnel"
-  href="/guides/getting-started"
+  href="/zh-cn/guides/getting-started"
 />
 
 <CardGrid>
   <LinkCard
     title="Regular safety audits and compliance checks"
-    href="/guides/getting-started"
+    href="/zh-cn/guides/getting-started"
   />
   <LinkCard
     title="Emergency response plans and drills"
-    href="/guides/getting-started"
+    href="/zh-cn/guides/getting-started"
   />
 </CardGrid>
 

--- a/src/content/docs/zh-cn/tools/equipment-care.mdx
+++ b/src/content/docs/zh-cn/tools/equipment-care.mdx
@@ -16,11 +16,11 @@ import {
 <Card title="Maintaining Your ScrewFast Tools" icon="approve-check-circle">
 <LinkCard
   description="Step-by-step guide for the routine care and maintenance of your ScrewFast tools to ensure long-lasting functionality."
-  href="/guides/getting-started"
+  href="/zh-cn/guides/getting-started"
 />
 <LinkCard
   description="Cleaning, storage, and inspection practices to keep tools in optimal condition"
-  href="/guides/getting-started"
+  href="/zh-cn/guides/getting-started"
 />
 </Card>
 


### PR DESCRIPTION
## fix(docs): update documentation links and navigation for locale support

### Overview

This pull request addresses two key issues related to language support in our Starlight-based documentation:

1. **Broken internal links** across translated documentation pages due to missing language prefixes.
2. **Navigation logo links** not preserving the user's language context, resulting in 404 errors when using `prefixDefaultLocale: true`.

---

### 🛠️ What’s Fixed

#### 1. Internal Documentation Links

- **Problem**: Links across localized docs did not include language prefixes (e.g., `/welcome-to-docs/` instead of `/en/welcome-to-docs/`), causing 404s.
- **Fix**: Updated 23 files across all supported locales (`en`, `de`, `es`, `fa`, `fr`, `ja`, `zh-cn`) to include the correct language prefix in internal links.
- **Result**: All internal links now resolve correctly when `prefixDefaultLocale` is enabled.

#### 2. Logo and Navigation Link Behavior

- **Problem**:
  - Main site logo always linked to `/`, ignoring the active locale.
  - Docs logo linked to `/welcome-to-docs/`, also missing the language prefix.
  - These behaviors caused users to lose their language context and hit 404s.

- **Fix**: Updated the `SiteTitle.astro` component to use reliable, layered locale detection:
  1. `Astro.props.lang`
  2. `Astro.locals.starlightRoute?.locale`
  3. `Astro.currentLocale`
  4. Fallback via URL path if needed

- **Result**:
  - Site logo now links to `/en/`, `/es/`, etc., depending on current language.
  - Docs logo now links to `/en/welcome-to-docs/`, `/es/welcome-to-docs/`, etc.
  - Language context is preserved across navigation, improving UX and avoiding routing errors.

---

### ✅ Supported Languages

All changes apply to and were tested across:

- English (`en`)
- German (`de`)
- Spanish (`es`)
- Persian (`fa`)
- French (`fr`)
- Japanese (`ja`)
- Simplified Chinese (`zh-cn`)